### PR TITLE
ScatterPlot.m: fix combined categories

### DIFF
--- a/ScatterPlot.m
+++ b/ScatterPlot.m
@@ -340,7 +340,7 @@ classdef ScatterPlot < handle
             %selChFiltered is part of obj.selCh for displayed channels, channel x fghjkl markings
             pocty = zeros(max(obj.categoriesSelectionIndex),3); % maximalni mozny index zobrazeneho kanalu
             for k = flip(obj.categoriesSelectionIndex) %nejpozdeji, cili nejvic na vrchu, chci mit prvni kategorii %1:numel(obj.categories)
-                colorIndex = obj.categories(k) + 1;
+                [categoryColor, categoryMarker] = obj.getCategoryIcon(k);
                 dataX = obj.getData(obj.axisX, k);
                 dataY = obj.getData(obj.axisY, k);
                 if obj.is3D
@@ -350,12 +350,12 @@ classdef ScatterPlot < handle
                 iData = logical(selChFiltered(:,k)); %kanaly se signifikantim rozdilem vuci baseline v teto kategorii
                 if any(iData)
                     if obj.is3D
-                        obj.plots(k,1) = scatter3(obj.ax, dataX(iData), dataY(iData), dataZ(iData), obj.markerSize, repmat(obj.ieegdata.colorskat{colorIndex}, sum(iData), 1), ...
-                        	obj.categoryMarkers{colorIndex}, 'MarkerFaceColor', 'flat', 'DisplayName', obj.categoryNames{k});
+                        obj.plots(k,1) = scatter3(obj.ax, dataX(iData), dataY(iData), dataZ(iData), obj.markerSize, repmat(categoryColor, sum(iData), 1), ...
+                        	categoryMarker, 'MarkerFaceColor', 'flat', 'DisplayName', obj.categoryNames{k});
                         if obj.transparent, alpha(obj.plots(k,1),.5); end %volitelne pridani pruhlednosti
                     else
-                        obj.plots(k,1) = scatter(obj.ax, dataX(iData), dataY(iData), obj.markerSize, repmat(obj.ieegdata.colorskat{colorIndex}, sum(iData), 1), ...
-                        	obj.categoryMarkers{colorIndex}, 'MarkerFaceColor', 'flat', 'DisplayName', obj.categoryNames{k});
+                        obj.plots(k,1) = scatter(obj.ax, dataX(iData), dataY(iData), obj.markerSize, repmat(categoryColor, sum(iData), 1), ...
+                        	categoryMarker, 'MarkerFaceColor', 'flat', 'DisplayName', obj.categoryNames{k});
                         if obj.transparent, alpha(obj.plots(k,1),.5); end %volitelne pridani pruhlednosti
                     end
                     pocty(k,1) = sum(iData); %pocet signifikantnich v teto kategorii
@@ -368,12 +368,12 @@ classdef ScatterPlot < handle
                         handleVisibility = 'off';   % Pokud signif. rozdil mel, jeden graf uz se vytvoril i s legendu, takze nebudeme zobrazovat dalsi
                     end
                     if obj.is3D
-                        obj.plots(k,2) = scatter3(obj.ax, dataX(iData), dataY(iData), dataZ(iData), obj.markerSize, repmat(obj.ieegdata.colorskat{colorIndex}, sum(iData), 1), ...
-                        	obj.categoryMarkers{colorIndex}, 'MarkerFaceColor', 'none', 'DisplayName', obj.categoryNames{k},...
+                        obj.plots(k,2) = scatter3(obj.ax, dataX(iData), dataY(iData), dataZ(iData), obj.markerSize, repmat(categoryColor, sum(iData), 1), ...
+                        	categoryMarker, 'MarkerFaceColor', 'none', 'DisplayName', obj.categoryNames{k},...
                             'HandleVisibility', handleVisibility);
                     else
-                        obj.plots(k,2) = scatter(obj.ax, dataX(iData), dataY(iData), obj.markerSize, repmat(obj.ieegdata.colorskat{colorIndex}, sum(iData), 1), ...
-                        	obj.categoryMarkers{colorIndex}, 'MarkerFaceColor', 'none', 'DisplayName', obj.categoryNames{k},...
+                        obj.plots(k,2) = scatter(obj.ax, dataX(iData), dataY(iData), obj.markerSize, repmat(categoryColor, sum(iData), 1), ...
+                        	categoryMarker, 'MarkerFaceColor', 'none', 'DisplayName', obj.categoryNames{k},...
                             'HandleVisibility', handleVisibility);
                     end
                     pocty(k,2) = sum(iData); %pocet ne signifikantnich v teto kategorii
@@ -473,7 +473,7 @@ classdef ScatterPlot < handle
             hold(obj.ax, 'on');
             if idx
                 for k = obj.categoriesSelectionIndex
-                    colorIndex = obj.categories(k) + 1;
+                    [categoryColor, ~] = obj.getCategoryIcon(k);
                     dataX = obj.getData(obj.axisX, k);
                     dataY = obj.getData(obj.axisY, k);
                     if obj.is3D
@@ -481,9 +481,9 @@ classdef ScatterPlot < handle
                     end
                     
                     if obj.is3D
-                        obj.highlights(k) = scatter3(obj.ax, dataX(idx), dataY(idx), dataZ(idx), 3*obj.markerSize, 0.75*obj.ieegdata.colorskat{colorIndex}, 'o', 'MarkerFaceColor', 'none', 'LineWidth', 2, 'HandleVisibility','off');
+                        obj.highlights(k) = scatter3(obj.ax, dataX(idx), dataY(idx), dataZ(idx), 3*obj.markerSize, 0.75*categoryColor, 'o', 'MarkerFaceColor', 'none', 'LineWidth', 2, 'HandleVisibility','off');
                     else
-                        obj.highlights(k) = scatter(obj.ax, dataX(idx), dataY(idx), 3*obj.markerSize, 0.75*obj.ieegdata.colorskat{colorIndex}, 'o', 'MarkerFaceColor', 'none', 'LineWidth', 2, 'HandleVisibility','off');
+                        obj.highlights(k) = scatter(obj.ax, dataX(idx), dataY(idx), 3*obj.markerSize, 0.75*categoryColor, 'o', 'MarkerFaceColor', 'none', 'LineWidth', 2, 'HandleVisibility','off');
                     end
                 end
                 figure(obj.fig);
@@ -619,6 +619,17 @@ classdef ScatterPlot < handle
                 obj.highlightInMyPlots(0);
             end
             figure(obj.header.channelPlot.plotCh3D.fh);
+        end
+        
+        function [color, marker] = getCategoryIcon(obj, k)
+            % Return the color for the k-th category
+            if iscell(obj.categories) 
+                colorIndex = obj.categories{k}(1) + 1;
+            else
+                colorIndex = obj.categories(k) + 1;
+            end
+            color = obj.ieegdata.colorskat{colorIndex};
+            marker = obj.categoryMarkers{colorIndex};
         end
         
         function setDisplayedChannels(obj)


### PR DESCRIPTION
 * new function [color, marker] = getCategoryIcon(k) should
   consistently return correct k-th category color and marker